### PR TITLE
Link to our (now) live public documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node-RED Dashboard 2.0
 
-Documentation can be found here: 
+Documentation can be found here: https://flowforge.github.io/flowforge-nr-dashboard/
 
 ## Installation
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -5,7 +5,7 @@ export default {
         lang: 'en',
         label: 'English',
         title: 'Node-RED Dashboard 2.0',
-        description: 'Vue-powered Static Site Generator',
+        description: 'Documentation for Node-RED Dashboard 2.0, a collection of nodes to build out data visualisations and dashboards in Node-RED',
       }
     },
     themeConfig: {


### PR DESCRIPTION
## Description

Adds a link in our README to our public documentation and updates the site description in config for when sharing the URL.