### PR TITLE
Add "ui-markdown" widget

### DIFF
--- a/docs/nodes/widgets/ui-markdown.md
+++ b/docs/nodes/widgets/ui-markdown.md
@@ -1,0 +1,18 @@
+https://flowforge.com/handbook/development/markdown-how-to/#markdown-how-to
+
+---
+props:
+    Page: Defines with page of the UI Dashboard this widget will render on
+    Contents: The markdown to be passed to the UI and rendered
+---
+
+<script setup>
+</script>
+
+# Markdown Viewer `ui-markdown`
+
+Allows for markdown to be defined within Node-RED editor and rendered into the UI. Can be use for rendering labels, headers or even full blog articles.
+
+## Properties
+
+<PropsTable/>

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -89,10 +89,13 @@
 <script type="text/html" data-template-name="ui-markdown">
     <div class="form-row">
         <label for="node-input-page"><i class="fa fa-table"></i> Page</label>
-        <input type="text" id="node-input-page">
+        <input style="flex-grow:1" type="text" id="node-input-page">
     </div>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <div style="flex-grow: 1">
+            <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
+        </div>
     </div>
     <div class="form-row" style="margin-bottom:0px;">
         <label for="node-input-content"><i class="fa fa-copy"></i> Content</label>

--- a/nodes/widgets/ui_markdown.html
+++ b/nodes/widgets/ui_markdown.html
@@ -1,0 +1,104 @@
+<script type="text/javascript">
+    // convert to i18 text
+    function c_(x) {
+        return RED._("node-red-dashboard/ui-template:ui-template."+x);
+    }
+
+    RED.nodes.registerType('ui-markdown',{
+        category: RED._("node-red-dashboard/ui_base:ui_base.label.category"),
+        color: 'rgb( 63, 173, 181)',
+        defaults: {
+            page: { type: 'ui-page', required: true },
+            name: {value: ''},
+            order: {value: 0},
+            width: {value: 0, validate: function(v) {
+                    var valid = true
+                    if (this.templateScope !== 'global') {
+                        var width = v||0;
+                        var currentGroup = $('#node-input-group').val() || this.group;
+                        var groupNode = RED.nodes.node(currentGroup);
+                        valid = !groupNode || +width <= +groupNode.width;
+                        $("#node-input-size").toggleClass("input-error",!valid);
+                    }
+                    return valid;
+                }},
+            height: {value: 0},
+            content: {value: '# Markdown Content\n\nGoes here...'}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "ui-template.png",
+        paletteLabel: 'markdown',
+        label: function() { return this.name || 'markdown'; },
+        labelStyle: function() { return this.name?"node_label_italic":""; },
+        oneditprepare: function() {
+            var that = this;
+
+            this.editor = RED.editor.createEditor({
+                id: 'node-input-content-editor',
+                mode: 'ace/mode/markdown',
+                value: $("#node-input-content").val()
+            });
+
+            RED.library.create({
+                url: "uimarkdown", // where to get the data from
+                type: "ui-markdown", // the type of object the library is for
+                editor: this.editor, // the field name the main text body goes to
+                mode: "ace/mode/markdown",
+                fields: ['name']
+            });
+
+            this.editor.focus();
+
+            RED.popover.tooltip($("#node-markdown-expand-editor"),c_("label.expand"));
+        },
+        oneditsave: function() {
+            var annot = this.editor.getSession().getAnnotations();
+            this.noerr = 0;
+            $("#node-input-noerr").val(0);
+            for (var k=0; k < annot.length; k++) {
+                if (annot[k].type === "error") {
+                    $("#node-input-noerr").val(annot.length);
+                    this.noerr = annot.length;
+                }
+            }
+            console.log('edit content')
+            console.log(this.editor.getValue())
+            $("#node-input-content").val(this.editor.getValue());
+            this.editor.destroy();
+            delete this.editor;
+        },
+        oneditcancel: function() {
+            this.editor.destroy();
+            delete this.editor;
+        },
+        oneditresize: function(size) {
+            var rows = $("#dialog-form>div:not(.node-text-editor-row)");
+            var height = $("#dialog-form").height();
+            for (var i=0; i<rows.size(); i++) {
+                height = height - $(rows[i]).outerHeight(true);
+            }
+            var editorRow = $("#dialog-form>div.node-text-editor-row");
+            height -= (parseInt(editorRow.css("marginTop")) + parseInt(editorRow.css("marginBottom")));
+            $(".node-text-editor").css("height",height+"px");
+            this.editor.resize();
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="ui-markdown">
+    <div class="form-row">
+        <label for="node-input-page"><i class="fa fa-table"></i> Page</label>
+        <input type="text" id="node-input-page">
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+    </div>
+    <div class="form-row" style="margin-bottom:0px;">
+        <label for="node-input-content"><i class="fa fa-copy"></i> Content</label>
+        <input type="hidden" id="node-input-content">
+    </div>
+    <div class="form-row node-text-editor-row" style="display: block;">
+        <div style="height:250px; min-height:100px" class="node-text-editor" id="node-input-content-editor" ></div>
+    </div>
+</script>

--- a/nodes/widgets/ui_markdown.js
+++ b/nodes/widgets/ui_markdown.js
@@ -1,0 +1,14 @@
+module.exports = function(RED) {
+    function MarkdownNode(config) {
+        var node = this;
+
+        RED.nodes.createNode(this, config);
+
+        // which page are we rendering this widget
+        var page = RED.nodes.getNode(config.page);
+
+        // inform the dashboard UI that we are adding this node
+        page.register(node, config)
+    }
+    RED.nodes.registerType("ui-markdown", MarkdownNode);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "node-red-node-test-helper": "^0.3.2",
                 "socket.io-client": "^4.6.2",
                 "vitepress": "^1.0.0-beta.3",
+                "vue-markdown-render": "^2.0.1",
                 "vue-router": "^4.2.2",
                 "vuetify": "^3.3.3",
                 "vuex": "^4.1.0"
@@ -10019,6 +10020,15 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/linkify-it": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "dev": true,
+            "dependencies": {
+                "uc.micro": "^1.0.1"
+            }
+        },
         "node_modules/loader-runner": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10393,10 +10403,47 @@
             "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
             "dev": true
         },
+        "node_modules/markdown-it": {
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/mdn-data": {
             "version": "2.0.14",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
             "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+            "dev": true
+        },
+        "node_modules/mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
             "dev": true
         },
         "node_modules/media-typer": {
@@ -15018,6 +15065,12 @@
             "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
             "dev": true
         },
+        "node_modules/uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
         "node_modules/uglify-js": {
             "version": "3.16.3",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
@@ -15502,6 +15555,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/vue-markdown-render": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/vue-markdown-render/-/vue-markdown-render-2.0.1.tgz",
+            "integrity": "sha512-/UBCu0OrZ9zzEDtiZVwlV/CQ+CgcwViServGis3TRXSVc6+6lJxcaOcD43vRoQzYfPa9r9WDt0Q7GyupOmpEWA==",
+            "dev": true,
+            "dependencies": {
+                "markdown-it": "^12.3.2",
+                "vue": "^3.2.45"
             }
         },
         "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
             "ui-dropdown": "nodes/widgets/ui_dropdown.js",
             "ui-chart": "nodes/widgets/ui_chart.js",
             "ui-slider": "nodes/widgets/ui_slider.js",
+            "ui-markdown": "nodes/widgets/ui_markdown.js",
             "ui-template": "nodes/widgets/ui_template.js",
             "ui-text": "nodes/widgets/ui_text.js",
             "ui-text-input": "nodes/widgets/ui_text_input.js"
@@ -77,6 +78,7 @@
         "node-red-node-test-helper": "^0.3.2",
         "socket.io-client": "^4.6.2",
         "vitepress": "^1.0.0-beta.3",
+        "vue-markdown-render": "^2.0.1",
         "vue-router": "^4.2.2",
         "vuetify": "^3.3.3",
         "vuex": "^4.1.0"

--- a/ui/src/layouts/index.js
+++ b/ui/src/layouts/index.js
@@ -1,7 +1,5 @@
 import Flex from './Flex';
-import Grid from './Grid';
 
 export default { 
-    "flex": Flex,
-    "grid": Grid
+    "flex": Flex
 }

--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -26,3 +26,10 @@ body {
 main {
     padding: var(--nrdb-main-padding);
 }
+
+.nrdb-ui-markdown h1 {
+    margin: 0.67em 0;
+}
+.nrdb-ui-markdown p {
+    margin: 1em 0;
+}

--- a/ui/src/widgets/index.js
+++ b/ui/src/widgets/index.js
@@ -2,6 +2,7 @@ import UIButton from './ui-button/UIButton'
 import UIDropdown from './ui-dropdown/UIDropdown'
 import UIChart from './ui-chart/UIChart'
 import UISlider from './ui-slider/UISlider'
+import UIMarkdown from './ui-markdown/UIMarkdown'
 import UITemplate from './ui-template/UITemplate'
 import UIText from './ui-text/UIText'
 import UITextInput from './ui-text-input/UITextInput'
@@ -11,6 +12,7 @@ export default {
     'ui-dropdown': UIDropdown,
     'ui-chart': UIChart,
     'ui-slider': UISlider,
+    'ui-markdown': UIMarkdown,
     'ui-template': UITemplate,
     'ui-text': UIText,
     'ui-text-input': UITextInput

--- a/ui/src/widgets/ui-markdown/UIMarkdown.vue
+++ b/ui/src/widgets/ui-markdown/UIMarkdown.vue
@@ -1,0 +1,52 @@
+<template>
+    <vue-markdown class="nrdb-ui-markdown" :source="props.content" />
+</template>
+
+<script>
+    import { useDataTracker } from '../data-tracker.js'
+    import { mapState } from 'vuex'
+
+    import VueMarkdown from 'vue-markdown-render'
+
+    export default {
+        name: 'DBUIMarkdown',
+        inject: ['$socket'],
+        props: {
+            id: String,
+            props: Object
+        },
+        components: {
+            VueMarkdown
+        },
+        computed: {
+            ...mapState('data', ['values']),
+        },
+        created () {
+            useDataTracker(this.id)
+        }
+    }
+</script>
+  
+<style lang="css">
+.nrdb-ui-markdown h1 {
+    margin: 0.67em 0;
+}
+.nrdb-ui-markdown h2 {
+    margin: 0.5em 0;
+}
+.nrdb-ui-markdown h3 {
+    margin: 0.25em 0;
+}
+.nrdb-ui-markdown ul {
+    padding: 0 0 0 1em;
+}
+.nrdb-ui-markdown p {
+    margin: 0.25em 0 1em;
+}
+.nrdb-ui-markdown blockquote {
+    padding-left: 1em;
+    border-left: 4px solid #d1d1d1;
+    color: gray;
+}
+</style>
+  


### PR DESCRIPTION
## Description

Adds a new widget to render markdown defined in the respective Node-RED node. No injection of content currently supported. Can be used for more verbose content around labelling, headers and even full blogs if required.

<img width="346" alt="Screenshot 2023-07-04 at 16 44 58" src="https://github.com/flowforge/flowforge-nr-dashboard/assets/99246719/57dc126f-8894-4300-9ca3-0a3aa53d324d">

<img width="513" alt="Screenshot 2023-07-04 at 16 45 06" src="https://github.com/flowforge/flowforge-nr-dashboard/assets/99246719/2850b913-1214-4ca1-a733-f5c061d75574">

## Related Issue(s)

First iteration for UI Template (https://github.com/flowforge/flowforge-nr-dashboard/issues/51) which just supports markdown. #51 did include full HTML/JS rendering and support though.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
