### PR TITLE
Enable simultaneous clients & Server re-architected

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -10,10 +10,6 @@
             path: {
                 value: "/ui",
                 required: true,
-            },
-            port: {
-                value: null,
-                required: false,
             }
         },
         label: function() {
@@ -230,9 +226,5 @@
     <div class="form-row">
         <label for="node-config-input-path"><i class="fa fa-bookmark"></i> Path</label>
         <input type="text" id="node-config-input-path">
-    </div>
-    <div class="form-row">
-        <label for="node-config-input-port"><i class="fa fa-bookmark"></i> Port</label>
-        <input type="text" id="node-config-input-port">
     </div>
 </script>

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -16,12 +16,14 @@ module.exports = function(RED) {
     // const ui = require('../../ui/src/main')
 
     // const emitter = new Emitter()
-    
+
     /**
      * 
      * @param {*} n 
      */
     function UIBaseNode(n) {
+        console.log('ui base node constructor')
+        console.log(this.app)
         const express = require('express')
 
         const node = this
@@ -31,13 +33,16 @@ module.exports = function(RED) {
         /**
          * Configure & Run Express Server
          */
-        node.port = 1881
+        node.port = n.port || 1880
 
 
         /** @type { import('express').Application } */
-        node.app = express()
-        node.app.use(express.json())
-        node.app.use(express.urlencoded({ extended: true }))
+        // node.app = express()
+        // node.app.use(express.json())
+        // node.app.use(express.urlencoded({ extended: true }))
+
+        node.app = RED.httpNode || RED.httpAdmin
+        const server = RED.server
 
         /**
          * Create Web Server
@@ -52,10 +57,10 @@ module.exports = function(RED) {
             res.sendFile(path.join(__dirname, '../../dist/index.html'));
         });       
         
-        const server = http.createServer(node.app)
-        server.listen(node.port, () => {
-            node.log(`Dashboard UI listening at ${n.path} on port ${node.port}`)
-        })
+        // const server = http.createServer(node.app)
+        // server.listen(node.port, () => {
+        //     node.log(`Dashboard UI listening at ${n.path} on port ${node.port}`)
+        // })
 
         // Make sure we clean up after ourselves
         node.on('close', async (done) => {


### PR DESCRIPTION
## Description

Re-architect server spin up such that we can run on the same port as Node-RED. This does mean we can no longe configure a ui-base to run on a different port. Not a major issue currently (as same with D1.0) but will look at this again in the future,

Also fixed `connections` state to handle multiple, simultaneous browsers/clients connecting to the NR instance at once. Previously, the latest would override any existing connections. This closes #71 

## Related Issue(s)

Closes #71 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

