### PR TITLE
replace scoped style with node specific selectors

### DIFF
--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -14,10 +14,6 @@ module.exports = function(RED) {
                 var error = null
                 var event = msg.event
 
-                if (event) {
-                    console.log('event triggered by UI button click')
-                }
-
                 // retrieve the payload we're sending from this button
                 var payloadType = config.payloadType;
                 var payload = config.payload;

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -12,7 +12,6 @@ module.exports = function(RED) {
             onAction: true,
             onInput: function (msg, send) {
                 var error = null
-                var event = msg.event
 
                 // retrieve the payload we're sending from this button
                 var payloadType = config.payloadType;

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -50,25 +50,25 @@
 </script>
 
 <script type="text/html" data-template-name="ui-slider">
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
         <input type="text" id="node-input-group">
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label><i class="fa fa-object-group"></i> Size</label>
         <input type="hidden" id="node-input-width">
         <input type="hidden" id="node-input-height">
         <button class="editor-button" id="node-input-size"></button>
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>
         <input type="text" id="node-input-label">
     </div>
-    <!--<div class="form-row">
+    <!--<div class="form-row ui-slider">
         <label for="node-input-tooltip"><i class="fa fa-info-circle"></i> Tooltip</label>
         <input type="text" id="node-input-tooltip" placeholder="optional tooltip">
     </div>-->
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label for="node-input-min"><i class="fa fa-arrows-h"></i> Range</label>
         <div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 70%">
             <div>
@@ -85,41 +85,50 @@
             </div>
         </div>
     </div>
-    <!-- <div class="form-row">
+    <!-- <div class="form-row ui-slider">
         <label for="node-input-outs"><i class="fa fa-sign-out"></i> Output</label>
         <select id="node-input-outs" style="width:204px">
             <option value="all">continuously while sliding</option>
             <option value="end">only on release</option>
         </select>
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
         <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label style="padding-left:25px; margin-right:-25px">Payload</label>
         <label style="width:auto">Current value</label>
     </div>
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
         <input type="text" id="node-input-topic">
     </div>-->
-    <div class="form-row">
+    <div class="form-row ui-slider">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name">
         <input type="hidden" id="node-input-topicType">
     </div>
 </script>
 
+<!-- 
 <style scoped>
-    .form-row {
+scoped is depreciated and not supported in most browsers instead use a unique
+class name for the style to make it specific to this widget.
+In this case, setting .form-row was affecting all other widgets - in particular the code editor.
+It was causing the clientWidth to be zero and thus the elementSizer was not working correctly.
+In short, we should be more specific with our CSS selectors on edit forms & probably handle the fragile
+code editor width issue in a different way - but for now, being more specific is the quick fix
+-->
+<style id="nr-db2-ui-slider-styles">
+    div.form-row.ui-slider {
         display: flex;
         align-items: center;
     }
-    .form-row label {
+    div.form-row.ui-slider label {
         margin-bottom: 0;
     }
 </style>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -117,11 +117,11 @@
 </script>
 
 <style id="nr-db2-ui-slider-styles">
-    .red-ui-editor div.ui-slider.form-row {
+    .red-ui-editor div.ui-slider .form-row {
         display: flex;
         align-items: center;
     }
-    .red-ui-editor div.ui-slider.form-row label {
+    .red-ui-editor div.ui-slider .form-row label {
         margin-bottom: 0;
     }
 </style>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -50,7 +50,7 @@
 </script>
 
 <script type="text/html" data-template-name="ui-slider">
-    <div class="form-rows">
+    <div class="ui-slider">
         <div class="form-row">
             <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
             <input type="text" id="node-input-group">
@@ -116,21 +116,12 @@
     </div>
 </script>
 
-<!-- 
-<style scoped>
-scoped is depreciated and not supported in most browsers instead use a unique
-class name for the style to make it specific to this widget.
-In this case, setting .form-row was affecting all other widgets - in particular the code editor.
-It was causing the clientWidth to be zero and thus the elementSizer was not working correctly.
-In short, we should be more specific with our CSS selectors on edit forms & probably handle the fragile
-code editor width issue in a different way - but for now, being more specific is the quick fix
--->
 <style id="nr-db2-ui-slider-styles">
-    .red-ui-editor div.form-rows.form-row {
+    .red-ui-editor div.ui-slider.form-row {
         display: flex;
         align-items: center;
     }
-    .red-ui-editor div.form-rows.form-row label {
+    .red-ui-editor div.ui-slider.form-row label {
         margin-bottom: 0;
     }
 </style>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -50,67 +50,69 @@
 </script>
 
 <script type="text/html" data-template-name="ui-slider">
-    <div class="form-row ui-slider">
-        <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
-        <input type="text" id="node-input-group">
-    </div>
-    <div class="form-row ui-slider">
-        <label><i class="fa fa-object-group"></i> Size</label>
-        <input type="hidden" id="node-input-width">
-        <input type="hidden" id="node-input-height">
-        <button class="editor-button" id="node-input-size"></button>
-    </div>
-    <div class="form-row ui-slider">
-        <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>
-        <input type="text" id="node-input-label">
-    </div>
-    <!--<div class="form-row ui-slider">
-        <label for="node-input-tooltip"><i class="fa fa-info-circle"></i> Tooltip</label>
-        <input type="text" id="node-input-tooltip" placeholder="optional tooltip">
-    </div>-->
-    <div class="form-row ui-slider">
-        <label for="node-input-min"><i class="fa fa-arrows-h"></i> Range</label>
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 70%">
-            <div>
-                <span for="node-input-min">min</span>
-                <input type="text" id="node-input-min" style="width:60px">
-            </div>
-            <div>
-                <span for="not-input-step">step</span>
-                <input type="text" id="node-input-step" style="width:60px">
-            </div>
-            <div>
-                <span for="not-input-max">max</span>
-                <input type="text" id="node-input-max" style="width:60px">
+    <div class="form-rows">
+        <div class="form-row">
+            <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
+            <input type="text" id="node-input-group">
+        </div>
+        <div class="form-row">
+            <label><i class="fa fa-object-group"></i> Size</label>
+            <input type="hidden" id="node-input-width">
+            <input type="hidden" id="node-input-height">
+            <button class="editor-button" id="node-input-size"></button>
+        </div>
+        <div class="form-row">
+            <label for="node-input-label"><i class="fa fa-i-cursor"></i> Label</label>
+            <input type="text" id="node-input-label">
+        </div>
+        <!--<div class="form-row">
+            <label for="node-input-tooltip"><i class="fa fa-info-circle"></i> Tooltip</label>
+            <input type="text" id="node-input-tooltip" placeholder="optional tooltip">
+        </div>-->
+        <div class="form-row">
+            <label for="node-input-min"><i class="fa fa-arrows-h"></i> Range</label>
+            <div style="display: grid; grid-template-columns: repeat(3, 1fr); width: 70%">
+                <div>
+                    <span for="node-input-min">min</span>
+                    <input type="text" id="node-input-min" style="width:60px">
+                </div>
+                <div>
+                    <span for="not-input-step">step</span>
+                    <input type="text" id="node-input-step" style="width:60px">
+                </div>
+                <div>
+                    <span for="not-input-max">max</span>
+                    <input type="text" id="node-input-max" style="width:60px">
+                </div>
             </div>
         </div>
-    </div>
-    <!-- <div class="form-row ui-slider">
-        <label for="node-input-outs"><i class="fa fa-sign-out"></i> Output</label>
-        <select id="node-input-outs" style="width:204px">
-            <option value="all">continuously while sliding</option>
-            <option value="end">only on release</option>
-        </select>
-    </div>
-    <div class="form-row ui-slider">
-        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
-        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
-    </div>
-    <div class="form-row ui-slider">
-        <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>
-    </div>
-    <div class="form-row ui-slider">
-        <label style="padding-left:25px; margin-right:-25px">Payload</label>
-        <label style="width:auto">Current value</label>
-    </div>
-    <div class="form-row ui-slider">
-        <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
-        <input type="text" id="node-input-topic">
-    </div>-->
-    <div class="form-row ui-slider">
-        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
-        <input type="text" id="node-input-name">
-        <input type="hidden" id="node-input-topicType">
+        <!-- <div class="form-row">
+            <label for="node-input-outs"><i class="fa fa-sign-out"></i> Output</label>
+            <select id="node-input-outs" style="width:204px">
+                <option value="all">continuously while sliding</option>
+                <option value="end">only on release</option>
+            </select>
+        </div>
+        <div class="form-row">
+            <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+            <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+        </div>
+        <div class="form-row">
+            <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>
+        </div>
+        <div class="form-row">
+            <label style="padding-left:25px; margin-right:-25px">Payload</label>
+            <label style="width:auto">Current value</label>
+        </div>
+        <div class="form-row">
+            <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
+            <input type="text" id="node-input-topic">
+        </div>-->
+        <div class="form-row">
+            <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+            <input type="text" id="node-input-name">
+            <input type="hidden" id="node-input-topicType">
+        </div>
     </div>
 </script>
 
@@ -124,11 +126,11 @@ In short, we should be more specific with our CSS selectors on edit forms & prob
 code editor width issue in a different way - but for now, being more specific is the quick fix
 -->
 <style id="nr-db2-ui-slider-styles">
-    div.form-row.ui-slider {
+    .red-ui-editor div.form-rows.form-row {
         display: flex;
         align-items: center;
     }
-    div.form-row.ui-slider label {
+    .red-ui-editor div.form-rows.form-row label {
         margin-bottom: 0;
     }
 </style>

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -64,11 +64,6 @@ module.exports = function(RED) {
             }
         }
 
-        console.log(config.onvalue)
-        console.log(config.onvalueType)
-        console.log(config.offvalue)
-        console.log(config.offvalueType)
-
         const on = RED.util.evaluateNodeProperty(config.onvalue, config.onvalueType, node)
         const off = RED.util.evaluateNodeProperty(config.offvalue, config.offvalueType, node)
 


### PR DESCRIPTION
fixes #86

remove `scoped` from `<style>` and replace it with more specific specifiers to avoid affecting all `form-rows`