### PR TITLE
Ensure items are closed and cleaned up

### DIFF
--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -79,7 +79,6 @@ module.exports = function (RED) {
      * Close the SocketIO Server
      */
     function close (node, done) {
-        console.log('📈 ui-base: close')
 
         if (!ui.ioServer) {
             done()

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -36,7 +36,6 @@ module.exports = function (RED) {
      * Initialise the Express Server and SocketIO Server in Singleton Pattern
      */
     function init (node, config) {
-        console.log('📈 ui-base: init', config)
         // eventually check if we have routes used, so we can support multiple base UIs
         if (!ui.app) {
             ui.app = RED.httpNode || RED.httpAdmin

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -79,7 +79,6 @@ module.exports = function (RED) {
      * Close the SocketIO Server
      */
     function close (node, done) {
-
         if (!ui.ioServer) {
             done()
             return
@@ -143,8 +142,6 @@ module.exports = function (RED) {
      * @param {*} n
      */
     function UIBaseNode (n) {
-        console.log('📈 ui-base: UIBaseNode instantiate', n)
-
         const node = this
         RED.nodes.createNode(node, n)
 

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -190,6 +190,7 @@ module.exports = function (RED) {
 
         // Make sure we clean up after ourselves
         node.on('close', (removed, done) => {
+            ui.ioServer?.off('connection', onConnection)
             close(node, function (err) {
                 if (err) {
                     node.error(`Error closing socket.io server for ${node.id}`, err)

--- a/nodes/config/ui_group.js
+++ b/nodes/config/ui_group.js
@@ -11,6 +11,11 @@ module.exports = function (RED) {
         const page = RED.nodes.getNode(config.page)
         node.log('UI Page Constructor')
 
+        node.on('close', function (removed, done) {
+            node.deregister() // deregister self
+            done()
+        })
+
         /**
          * Function for widgets to register themselves with this page
          * Calls the parent UI Base "register" function and registers this page,
@@ -20,6 +25,11 @@ module.exports = function (RED) {
         node.register = function (widgetNode, widgetConfig, widgetEvents) {
             const group = config
             page.register(group, widgetNode, widgetConfig, widgetEvents)
+        }
+
+        node.deregister = function (widgetNode) {
+            const group = config
+            page.deregister(group, widgetNode)
         }
     }
     RED.nodes.registerType('ui-group', UIGroupNode)

--- a/nodes/config/ui_page.js
+++ b/nodes/config/ui_page.js
@@ -11,6 +11,11 @@ module.exports = function (RED) {
         const ui = RED.nodes.getNode(config.ui)
         node.log('UI Page Constructor')
 
+        node.on('close', function (removed, done) {
+            node.deregister() // deregister self
+            done()
+        })
+
         /**
          * Function for widgets to register themselves with this page
          * Calls the parent UI Base "register" function and registers this page,
@@ -20,6 +25,10 @@ module.exports = function (RED) {
         node.register = function (group, widgetNode, widgetConfig, widgetEvents) {
             const page = config
             ui.register(page, group, widgetNode, widgetConfig, widgetEvents)
+        }
+        node.deregister = function (group, widgetNode) {
+            const page = config
+            ui.deregister(page, group, widgetNode)
         }
     }
     RED.nodes.registerType('ui-page', UIPageNode)


### PR DESCRIPTION
1. Ensure close is called for all types - not just widgets
2. inform each items parent of removal
   1. this ends up at the ui-base where de-registration occurs
3. close the socket.io server when there is nothing left to service

