### PR TITLE
Set default endpoint to /dashboard & disable the text field in ui-base

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -11,7 +11,7 @@
                 required: true
             },
             path: {
-                value: '/ui',
+                value: '/dashboard',
                 required: true
             }
         },
@@ -231,6 +231,7 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-path"><i class="fa fa-bookmark"></i> Path</label>
-        <input type="text" id="node-config-input-path">
+        <input type="text" id="node-config-input-path" disabled>
+        <span style="display: block; margin-left: 105px; margin-top: 0px; font-style: italic; color: #bbb; font-size: 8pt;">This option is currently disabled and still in-development.</span>
     </div>
 </script>


### PR DESCRIPTION
## Description

- Change default endpoint to `/dashboard`
- Disabled text field in `ui-base`

## Related Issue(s)

#70 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
