### PR TITLE
Link to Dashboard & Add Sidebar

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -1,5 +1,18 @@
+<style>
+    #ff-node-red-dashboard .red-ui-sidebar-header {
+        display: flex;
+        justify-content: space-between;
+    }
+    #ff-node-red-dashboard .red-ui-sidebar-header label {
+        margin-bottom: 0;
+    }
+</style>
+
+
 <script type="text/javascript">
 (function () {
+    const sidebarContentTemplate = '<div id="ff-node-red-dashboard"></div>'
+
     function hasProperty (obj, prop) {
         return Object.prototype.hasOwnProperty.call(obj, prop)
     }
@@ -18,6 +31,36 @@
         label: function () {
             return `${this.name} [${this.path}]` || 'UI Config'
         }
+    })
+
+    // Add Custom Dashboard Side Menu
+
+    const content = $(sidebarContentTemplate)
+
+    const uiRow = $('<div class="red-ui-sidebar-header"></div>')
+        .appendTo(content)
+
+    $('<label>Dashboard 2.0 UI</label><a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button">Open Dashboard<i style="margin-left: 3px;" class="fa fa-external-link"></i></a>')
+        .appendTo(uiRow)
+
+    RED.sidebar.addTab({
+        id: 'dashboard-2.0',
+        label: 'Dashboard 2.0',
+        name: 'Dashboard 2.0',
+        content,
+        closeable: true,
+        pinned: true,
+        disableOnEdit: true,
+        iconClass: 'fa fa-bar-chart',
+        action: '@flowforge/node-red-dashboard:show-dashboard-2.0-tab',
+        onchange: function () {
+            console.log('onload of sidebar')
+            // refresh();
+        }
+    })
+
+    RED.actions.add('@flowforge/node-red-dashboard:show-dashboard-2.0-tab', function () {
+        RED.sidebar.show('flowforge-nr-tools')
     })
 
     /**

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -16,6 +16,7 @@
     function hasProperty (obj, prop) {
         return Object.prototype.hasOwnProperty.call(obj, prop)
     }
+
     RED.nodes.registerType('ui-base', {
         category: 'config',
         defaults: {
@@ -33,15 +34,15 @@
         }
     })
 
-    // Add Custom Dashboard Side Menu
+    /**
+     * Add Custom Dashboard Side Menu
+     * */
 
     const content = $(sidebarContentTemplate)
 
-    const uiRow = $('<div class="red-ui-sidebar-header"></div>')
-        .appendTo(content)
-
-    $('<label>Dashboard 2.0 UI</label><a href="#" class="editor-button editor-button-small nr-db-sb-list-header-button">Open Dashboard<i style="margin-left: 3px;" class="fa fa-external-link"></i></a>')
-        .appendTo(uiRow)
+    function uiLink (name, path) {
+        return `<div class="red-ui-sidebar-header"><label>${name}</label><a id="open-dashboard" href="${path}" target="nr-dashboard" class="editor-button editor-button-small nr-db-sb-list-header-button">Open Dashboard<i style="margin-left: 3px;" class="fa fa-external-link"></i></a></div>`
+    }
 
     RED.sidebar.addTab({
         id: 'dashboard-2.0',
@@ -54,8 +55,14 @@
         iconClass: 'fa fa-bar-chart',
         action: '@flowforge/node-red-dashboard:show-dashboard-2.0-tab',
         onchange: function () {
-            console.log('onload of sidebar')
-            // refresh();
+            content.empty()
+            RED.nodes.eachConfig(function (n) {
+                if (n.type === 'ui-base') {
+                    content.append(uiLink(n.name, n.path))
+                }
+            })
+            // placeholder message
+            content.append('<span style="padding: 9px; font-style: italic; color: #a2a2a2; font-size: 8pt;">More content will be added here in future releases</span>')
         }
     })
 


### PR DESCRIPTION
## Description

Adds sidebar (with just a single link to the Dashboard for now)

<img width="466" alt="Screenshot 2023-08-04 at 12 35 57" src="https://github.com/flowforge/flowforge-nr-dashboard/assets/99246719/d397c016-c26d-4ea8-bb5d-f0720f409d17">

Also adds a command to the actions palette to open the sidebar:

<img width="594" alt="Screenshot 2023-08-04 at 12 36 25" src="https://github.com/flowforge/flowforge-nr-dashboard/assets/99246719/403c69cb-4bf5-4ad5-9014-107ecc08d48b">

## Related Issue(s)

Closes #79 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)