### PR TITLE
Event emitter improvements

### DIFF
--- a/docs/contributing/guides/adding-widgets.md
+++ b/docs/contributing/guides/adding-widgets.md
@@ -51,7 +51,7 @@ When adding a new widget, you will need to follow the steps below to ensure that
                     payload: 'hello world'
                 }
                 // send an event to Node-RED to inform it that we've clicked this widget
-                this.$socket.emit('widget-action:' + this.id, msg)
+                this.$socket.emit('widget-action', this.id, msg)
             }
         }
     }

--- a/docs/contributing/guides/events.md
+++ b/docs/contributing/guides/events.md
@@ -19,17 +19,20 @@ Used to transport dashboard/theme/page/groups/[widget](#widget) layout data, eac
 
 Sent from NR to UI when a msg input is received into a Dashboard node.
 
-### `widget-load:<node-id>`
+### `widget-load`
+- ID: `<node-id>`
 - Payload: `none`
 
 Sent from UI to NR when the UI/widget is first loaded. Gives a chance for NR to provide the widget with any known existing values.
 
-### `widget-change:<node-id>`
+### `widget-change`
+- ID: `<node-id>`
 - Payload: `<value>` - typically the payload data to be sent in the msg
 
 Sent from UI to NR when the value of a widget is changed from the UI, e.g. text input, slider
 
-### `widget-action:<node-id>`
+### `widget-action`
+- ID: `<node-id>`
 - Payload: `<msg>`
 
 Sent from UI to NR when a widget is actioned, e.g. click of a button or upload of a file

--- a/nodes/config/ui_base.js
+++ b/nodes/config/ui_base.js
@@ -546,7 +546,7 @@ module.exports = function (RED) {
 
         // Finally, queue up a config emit to the UI.
         // NOTE: this is a cautionary measure only - typically the registration of nodes will queue up a config emit
-        // but in the event no widgets are registered, we still need still emit a config
+        // but in cases where the dashboard has no widgets registered, we still need to emit a config
         node.requestEmitConfig()
     }
 

--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -10,7 +10,7 @@ module.exports = function (RED) {
 
         const evts = {
             onAction: true,
-            beforeSend: function (msg) {
+            beforeSend: async function (msg) {
                 let error = null
 
                 // retrieve the payload we're sending from this button
@@ -42,13 +42,8 @@ module.exports = function (RED) {
                         }
                     }
                 }
-                // retrieve the topic we're sending from this button
+
                 if (!error) {
-                    const topic = RED.util.evaluateNodeProperty(config.topic, config.topicType || 'str', node, msg)
-                    msg.payload = payload
-                    if (topic) {
-                        msg.topic = topic
-                    }
                     return msg
                 } else {
                     return null

--- a/ui/src/widgets/data-tracker.js
+++ b/ui/src/widgets/data-tracker.js
@@ -46,7 +46,7 @@ export function useDataTracker (widgetId, onInput) {
             })
             // let Node-RED know that this widget has loaded
             // useful as Node-RED can return (via msg-input) any stored data
-            socket.emit('widget-load:' + widgetId)
+            socket.emit('widget-load', widgetId)
         }
     })
     onUnmounted(() => {

--- a/ui/src/widgets/ui-button/UIButton.vue
+++ b/ui/src/widgets/ui-button/UIButton.vue
@@ -31,7 +31,7 @@ export default {
             }
             const msg = this.messages[this.id] || {}
             msg._event = evt
-            this.$socket.emit(`widget-action:${this.id}`, msg)
+            this.$socket.emit('widget-action', this.id, msg)
         }
     }
 }

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -78,6 +78,10 @@ export default {
             // ensure we set our local "value" to match
             this.value = payload
         })
+
+        // let Node-RED know that this widget has loaded
+        // useful as Node-RED can return (via msg-input) any stored data
+        this.$socket.emit('widget-load', this.id)
     },
     methods: {
         onChange () {
@@ -86,7 +90,7 @@ export default {
             const msg = this.messages[this.id] || {}
             msg.payload = this.value
             this.$store.commit('data/bind', msg)
-            this.$socket.emit(`widget-change:${this.id}`, msg.payload)
+            this.$socket.emit('widget-change', this.id, msg.payload)
         }
     }
 }

--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -90,7 +90,7 @@ export default {
             const msg = this.messages[this.id] || {}
             msg.payload = this.value
             this.$store.commit('data/bind', msg)
-            this.$socket.emit('widget-change', this.id, msg.payload)
+            this.$socket.emit('widget-change', this.id, this.value)
         }
     }
 }

--- a/ui/src/widgets/ui-slider/UISlider.vue
+++ b/ui/src/widgets/ui-slider/UISlider.vue
@@ -51,7 +51,7 @@ export default {
             const msg = this.messages[this.id] || {}
             msg.payload = this.value
             this.$store.commit('data/bind', msg)
-            this.$socket.emit(`widget-change:${this.id}`, this.value)
+            this.$socket.emit('widget-change', this.id, this.value)
         }
     }
 }

--- a/ui/src/widgets/ui-switch/UISwitch.vue
+++ b/ui/src/widgets/ui-switch/UISwitch.vue
@@ -60,11 +60,11 @@ export default {
         onChange () {
             // only runs when clicked/changed in UI.
             // inverted as the store doesn't quite update quick enough, but this is reliable method
-            this.$socket.emit(`widget-change:${this.id}`, !this.value)
+            this.$socket.emit('widget-change', this.id, !this.value)
         },
         toggle () {
             this.state = !this.state
-            this.$socket.emit(`widget-change:${this.id}`, this.state)
+            this.$socket.emit('widget-change', this.id, this.state)
         }
     }
 }

--- a/ui/src/widgets/ui-template/UITemplate.vue
+++ b/ui/src/widgets/ui-template/UITemplate.vue
@@ -44,7 +44,7 @@ export default {
             msg._dashboard = msg._dashboard || {}
             msg._dashboard.sourceId = component.id
             msg._dashboard.templateId = this.id
-            this.$socket.emit(`widget-action:${this.id}`, msg) // TODO: should we have a widget-send emitter to differentiate from action?
+            this.$socket.emit('widget-action', this.id, msg) // TODO: should we have a widget-send emitter to differentiate from action?
         },
         submit (component, $evt) {
             console.log('submit called from template item', component, $evt)
@@ -59,7 +59,7 @@ export default {
             msg._dashboard = msg._dashboard || {}
             msg._dashboard.sourceId = component.id
             msg._dashboard.templateId = this.id
-            this.$socket.emit(`widget-action:${this.id}`, msg) // TODO: should we have a widget-send emitter to differentiate from action?
+            this.$socket.emit('widget-action', this.id, msg) // TODO: should we have a widget-send emitter to differentiate from action?
         }
     }
 }

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -51,8 +51,7 @@ export default {
     },
     methods: {
         onBlur: function () {
-            console.log('blur', this.messages[this.id])
-            this.$socket.emit('widget-change', this.id, this.messages[this.id])
+            this.$socket.emit('widget-change', this.id, this.value)
         }
     }
 }

--- a/ui/src/widgets/ui-text-input/UITextInput.vue
+++ b/ui/src/widgets/ui-text-input/UITextInput.vue
@@ -52,7 +52,7 @@ export default {
     methods: {
         onBlur: function () {
             console.log('blur', this.messages[this.id])
-            this.$socket.emit(`widget-change:${this.id}`, this.messages[this.id])
+            this.$socket.emit('widget-change', this.id, this.messages[this.id])
         }
     }
 }


### PR DESCRIPTION
closes #96 
closes #102 

## Description

* uses common handlers for the 3 widget socket.io channels - instead of - an event hander per widget per handler
* ensures clean up socket io handlers on disconnect / close
* ensures emit config is requested when a node is added or removed in all deploy modes
* updates docs
* improved jsdoc type hints in ui-base
* removes the need for tracking load/change/action events
* only emits config to "own nodes connections"
   * prior, all connections (regardless of which base they belong to) were issued a config when any 1 base was updated. Now, only sockets connected to `this` base are emitted new config

## Related Issue(s)

#96 
#102 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

