### PR TITLE
Ensure msg.payload is assigned in button beforeSend

### DIFF
--- a/nodes/widgets/ui_button.js
+++ b/nodes/widgets/ui_button.js
@@ -43,6 +43,8 @@ module.exports = function (RED) {
                     }
                 }
 
+                msg.payload = payload
+
                 if (!error) {
                     return msg
                 } else {


### PR DESCRIPTION
## Description

As part of the event restructure we've missed the assigned of `msg.payload` in the button's beforeSend. This adds it back.

## Related Issue(s)

Fixes #109

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)