### PR TITLE
Review additions and fixes for branch "136 ordering"

### DIFF
--- a/nodes/config/locales/en-US/ui_base.json
+++ b/nodes/config/locales/en-US/ui_base.json
@@ -6,7 +6,9 @@
         },
         "layout": {
             "pages": "Pages",
-            "edit": "Edit"
+            "edit": "Edit",
+            "collapse": "Collapse",
+            "expand": "Expand"
         }
     }
 }

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -287,6 +287,9 @@
 
                 // add our changes to NR history and trigger whether or not we need to redeploy
                 recordEvents(events)
+            },
+            sort: function (a, b) {
+                return Number(a.order) - Number(b.order)
             }
         })
 
@@ -339,6 +342,9 @@
 
                 // add our changes to NR history and trigger whether or not we need to redeploy
                 recordEvents(events)
+            },
+            sort: function (a, b) {
+                return Number(a.order) - Number(b.order)
             }
         })
 
@@ -429,6 +435,9 @@
 
                 // add our changes to NR history and trigger whether or not we need to redeploy
                 recordEvents(events)
+            },
+            sort: function (a, b) {
+                return Number(a.order) - Number(b.order)
             }
         })
 

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -95,7 +95,20 @@
     function hasProperty (obj, prop) {
         return Object.prototype.hasOwnProperty.call(obj, prop)
     }
-
+    function debounce (func, wait, immediate) {
+        let timeout
+        return function () {
+            const context = this; const args = arguments
+            const later = function () {
+                timeout = null
+                if (!immediate) func.apply(context, args)
+            }
+            const callNow = immediate && !timeout
+            clearTimeout(timeout)
+            timeout = setTimeout(later, wait)
+            if (callNow) func.apply(context, args)
+        }
+    }
     RED.nodes.registerType('ui-base', {
         category: 'config',
         defaults: {
@@ -175,6 +188,33 @@
         RED.nodes.dirty(true)
         RED.view.redraw()
     }
+
+    // watch for nodes changed, added, removed - use this to refresh the sidebar
+    const refreshLayoutEditorDebounced = debounce(refreshLayoutEditor, 300)
+    RED.events.on('nodes:change', function (event) {
+        if (RED._db2debug) { console.log('nodes:change', event) }
+        if (event.dirty && event.type && event.type.startsWith('ui-')) {
+            if (RED._db2debug) { console.log('nodes:change - this is a ui- node! queuing a call to refreshLayoutEditor') }
+            // debounce the call to refreshLayoutEditor as multiple events can be fired in quick succession
+            refreshLayoutEditorDebounced()
+        }
+    })
+    RED.events.on('nodes:add', function (event) {
+        if (RED._db2debug) { console.log('nodes:add', event) }
+        if (event.dirty && event.type && event.type.startsWith('ui-')) {
+            if (RED._db2debug) { console.log('nodes:add - this is a ui- node! queuing a call to refreshLayoutEditor') }
+            // debounce the call to refreshLayoutEditor as multiple events can be fired in quick succession
+            refreshLayoutEditorDebounced()
+        }
+    })
+    RED.events.on('nodes:remove', function (event) {
+        if (RED._db2debug) { console.log('nodes:remove', event) }
+        if (event.dirty && event.type && event.type.startsWith('ui-')) {
+            if (RED._db2debug) { console.log('nodes:remove - this is a ui- node! queuing a call to refreshLayoutEditor') }
+            // debounce the call to refreshLayoutEditor as multiple events can be fired in quick succession
+            refreshLayoutEditorDebounced()
+        }
+    })
 
     /**
      * Add group of actions to the right-side of a row in the sidebar editable list.
@@ -309,7 +349,7 @@
 
     function buildLayoutOrderEditor () {
         // layout/order editor
-        const divTabs = $('<div>', { class: 'nrdb2-layout-order-editor' }).appendTo(sidebar)
+        const divTabs = $('.nrdb2-layout-order-editor').length ? $('.nrdb2-layout-order-editor') : $('<div>', { class: 'nrdb2-layout-order-editor' }).appendTo(sidebar)
 
         // section header - Pages
         const pagesHeader = $('<div>', { class: 'nrdb2-layout-order-editor--pages' }).appendTo(divTabs)
@@ -402,6 +442,27 @@
 
             // })
         })
+
+        // call updateLayoutVisibility to sync display level
+        updateLayoutVisibility(layoutDisplayLevel)
+    }
+
+    function refreshLayoutEditor () {
+        if (RED._db2debug) { console.log('refreshLayoutEditor called') }
+        const layoutOrderDiv = $('.nrdb2-layout-order-editor')
+        // empty the list if any items exist
+        if (layoutOrderDiv.length) {
+            // TODO: create a lookup of which items are expanded / collapsed
+            layoutOrderDiv.empty()
+        }
+
+        // now rebuild
+        buildLayoutOrderEditor()
+
+        // finally, restore previous state of expanded/collapsed items
+        // TODO: expand/collapse any items that were expanded before
+        // for now, we will just re-sync the display level
+        updateLayoutVisibility(layoutDisplayLevel)
     }
 
     RED.sidebar.addTab({

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -143,23 +143,27 @@
     function updateItemOrder (items, events) {
         items.each((i, el) => {
             const node = el.data('data')
+            const nodeBefore = RED.nodes.node(node.id)
             if (node.order !== i + 1) {
-                // update the order property for exposure to UI, start from 1, makes backup to SAFE_INT logic easier on frontend
-                node.order = i + 1
-                // update Node-RED node properties to trigger a redeploy
+                const originalOrder = nodeBefore.order
+                const wasDirty = node.dirty
+                const wasChanged = node.changed
+                // update Node-RED node properties
+                node.order = i + 1 // start from 1, makes backup to SAFE_INT logic easier on frontend
                 node.dirty = true
                 node.changed = true
+                // generate a history event
+                const hev = {
+                    t: 'edit',
+                    node,
+                    changes: {
+                        order: originalOrder
+                    },
+                    dirty: wasDirty,
+                    changed: wasChanged
+                }
+                events.push(hev)
             }
-            const hev = {
-                t: 'edit',
-                node,
-                changes: {
-                    order: node.order
-                },
-                dirty: node.dirty,
-                changed: node.changed
-            }
-            events.push(hev)
         })
     }
 
@@ -180,10 +184,17 @@
 
     // Utility function to store events in NR history, trigger a redraw, and detect if a re-deploy is necessary
     function recordEvents (events) {
+        if (events.length === 0) { return } // nothing to record
+
+        // note the state of the editor before pushing to history
+        const isDirty = RED.nodes.dirty()
+        if (RED._db2debug) { console.log('recordEvents', isDirty, events) }
+
         // add our changes to NR history and trigger whether or not we need to redeploy
         RED.history.push({
             t: 'multi',
-            events
+            events,
+            dirty: isDirty
         })
         RED.nodes.dirty(true)
         RED.view.redraw()
@@ -270,15 +281,16 @@
                 items.each((i, el) => {
                     const widget = el.data('data')
                     if (widget.page !== pageId) {
+                        const oldPageId = widget.page
                         widget.page = pageId
                         events.push({
                             t: 'edit',
                             node: widget,
                             changes: {
-                                page: widget.page
+                                page: oldPageId
                             },
-                            dirty: widget.dirty,
-                            changed: widget.changed
+                            dirty: widget.changed,
+                            changed: widget.dirty
                         })
                     }
                 })
@@ -294,7 +306,7 @@
         })
 
         groups.forEach(function (group) {
-            console.log(group)
+            if (RED._db2debug) { if (RED._db2debug) { console.log(group) } }
             groupsOL.editableList('addItem', group)
         })
     }
@@ -325,12 +337,13 @@
                 items.each((i, el) => {
                     const widget = el.data('data')
                     if (widget.group !== groupId) {
+                        const oldGroupId = widget.group
                         widget.group = groupId
                         events.push({
                             t: 'edit',
                             node: widget,
                             changes: {
-                                group: widget.group
+                                group: oldGroupId
                             },
                             dirty: widget.dirty,
                             changed: widget.changed
@@ -442,7 +455,7 @@
         })
 
         Object.values(groupsByPage).sort((a, b) => a.order - b.order).forEach(function (groups) {
-            console.log(groups)
+            if (RED._db2debug) { console.log(groups) }
             const page = pages[groups[0].page]
             if (page) {
                 pagesOL.editableList('addItem', page)

--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -366,6 +366,50 @@
         })
     }
 
+    // expand / collapse buttons
+    let layoutDisplayLevel = 2 // all open by default
+    const getGroupsInLayout = function () {
+        const content = $('.nrdb2-layout-order-editor > .red-ui-editableList .nrdb2-sb-widget-list-container')
+        return {
+            content,
+            chevrons: content.parent().find('div.nrdb2-sb-list-header > .nrdb2-sb-list-chevron')
+        }
+    }
+    const getPagesInLayout = function () {
+        const content = $('.nrdb2-layout-order-editor > .red-ui-editableList .nrdb2-sb-group-list-container')
+        return {
+            content,
+            chevrons: content.parent().find('div.nrdb2-sb-pages-list-header > .nrdb2-sb-list-chevron')
+        }
+    }
+    const collapseLayoutItems = function ({ chevrons, content }) {
+        chevrons.css({ transform: 'rotate(-90deg)' })
+        content.slideUp()
+        content.addClass('nr-db-sb-collapsed')
+    }
+    const expandLayoutItems = function ({ chevrons, content }) {
+        chevrons.css({ transform: '' })
+        content.slideDown()
+        content.removeClass('nr-db-sb-collapsed')
+    }
+    /**
+     * Update the visibility of the layout editor expandable lists
+     * @param {0|1|2} level - 0 = collapse all, 1 = expand pages (groups collapsed), 2 = expand pages and groups (to expose widgets)
+     */
+    const updateLayoutVisibility = function (level) {
+        if (RED._db2debug) { console.log('updateLayoutVisibility', level) }
+        if (level === 2) {
+            expandLayoutItems(getGroupsInLayout())
+            expandLayoutItems(getPagesInLayout())
+        } else if (level === 1) {
+            expandLayoutItems(getPagesInLayout())
+            collapseLayoutItems(getGroupsInLayout())
+        } else {
+            collapseLayoutItems(getGroupsInLayout())
+            collapseLayoutItems(getPagesInLayout())
+        }
+    }
+
     function buildLayoutOrderEditor () {
         // layout/order editor
         const divTabs = $('.nrdb2-layout-order-editor').length ? $('.nrdb2-layout-order-editor') : $('<div>', { class: 'nrdb2-layout-order-editor' }).appendTo(sidebar)
@@ -377,18 +421,23 @@
         // toggle "all" buttons
         const buttonGroup = $('<div>', { class: 'nrdb2-sb-list-button-group' }).appendTo(pagesHeader)
 
-        // Toggle expand buttons
-        $('<a href="#" class="editor-button editor-button-small nrdb2-sb-list-header-button"><i class="fa fa-angle-double-up"></i></a>')
+        const buttonCollapse = $('<a href="#" class="editor-button editor-button-small nrdb2-sb-list-header-button"><i class="fa fa-angle-double-up"></i></a>')
             .click(function (evt) {
                 evt.preventDefault()
+                if (--layoutDisplayLevel < 0) { layoutDisplayLevel = 0 }
+                updateLayoutVisibility(layoutDisplayLevel)
             })
             .appendTo(buttonGroup)
+        RED.popover.tooltip(buttonCollapse, c_('layout.collapse'))
 
-        $('<a href="#" class="editor-button editor-button-small nrdb2-sb-list-header-button"><i class="fa fa-angle-double-down"></i></a>')
+        // expand button
+        const buttonExpand = $('<a href="#" class="editor-button editor-button-small nrdb2-sb-list-header-button"><i class="fa fa-angle-double-down"></i></a>')
             .click(function (evt) {
-                evt.preventDefault()
-            })
+                if (++layoutDisplayLevel > 2) { layoutDisplayLevel = 2 }
+                updateLayoutVisibility(layoutDisplayLevel)
+            }).appendTo(buttonGroup)
             .appendTo(buttonGroup)
+        RED.popover.tooltip(buttonExpand, c_('layout.expand'))
 
         const pages = {}
         const groupsByPage = {}

--- a/nodes/config/ui_group.html
+++ b/nodes/config/ui_group.html
@@ -13,7 +13,7 @@
             disp: { value: true } // show title on group card
         },
         label: function () {
-            const page = RED.nodes.node(this.page).name
+            const page = RED.nodes.node(this.page)?.name || ''
             return `${this.name} [${page}]` || 'UI Group'
         },
         oneditprepare: function () {

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -42,7 +42,8 @@
             })
         },
         label: function () {
-            const base = RED.nodes.node(this.ui).path
+            const baseNode = RED.nodes.node(this.ui)
+            const base = baseNode ? baseNode.path : '/'
             const path = this.path || ''
             return `${this.name} [${base}${path}]` || 'UI Page'
         }

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -73,7 +73,7 @@
     </div>
     <div class="form-row">
         <label for="node-config-input-layout"><i class="fa fa-bookmark"></i> Order</label>
-        <input type="text" id="node-config-input-layout">
-        <input type="hidden" id="node-config-input-layoutType">
+        <input type="text" id="node-config-input-order">
+        <input type="hidden" id="node-config-input-orderType">
     </div>
 </script>


### PR DESCRIPTION
## Description

### Issues resolved.

1. undo leaving deploy button "red"
   1. use workspace dirty state for the overall history data
1. undo not re-syncing the layout
   1. see below - ended up adding a new function to reload the layout, triggered by RED.events
1. [DOM] Found 2 elements with non-unique id #node-config-input-layoutType (ui-page)
1. definition errors in sidebar
    ```
    Definition error: ui-group.label TypeError: Cannot read properties of undefined (reading 'name')
    at Object.label (<anonymous>:16:51)
    at Object.getNodeLabel (red.js?v=:9682:50)
    at Object.refresh (red.js?v=:29951:41)
    at Object.show (red.js?v=:34877:38)
    at red.js?v=:41658:33
    ```
    ```
    Definition error: ui-page.label TypeError: Cannot read properties of undefined (reading 'path')
    at Proxy.label (<anonymous>:45:49)
    at Object.getNodeLabel (red.js?v=:9682:50)
    at Object.createNodeIcon (red.js?v=:9867:39)
    at getNodeLabel (red.js?v=:30369:19)
    at onNodeAdd (red.js?v=:30921:22)
    at Object.emit (red.js?v=:1024:39)
    at addNode (red.js?v=:4387:20)
    at Object.importNodes [as import] (red.js?v=:6165:28)
    at Object.success (red.js?v=:340:41)
    at c (vendor.js?v=:2:28294)
    ```
1. sidebar does not update when nodes are deleted from canvas
   1. added RED.events.on('nodes:remove', ...) to call refreshLayout
1. sidebar does not update when nodes are added to canvas
   1. added RED.events.on('nodes:add', ...) to call refreshLayout
1. undo of widget move to another group not working correctly
   1. add 2 groups with 3 widgets
   1. move a widget from the top of group1 to the bottom of group2
   1. hit undo - widget moves to top of the group2 (should move to group1)
1. unchanged events being added to undo buffer.
   1. guarded the undo code to not permit empty events into the buffer
1. items are not actually sorted by the order prop. 
   1. Added sort handler to editabeList
1. nodes are still marked dirty after undo stack is emptied (after redo)
   1. use previous dirty/changed state for the undo data
1. re-arranging pages does not stick after refresh
   1. was due to no sort hander (actual order was being updated, but rendering was incorrect)
1. expand/collapse not hooked up
   1. wrote code to do 3 level collapse/expand


https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/0273d7d0-218d-42ea-8e76-e7369257a748


https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/deda99dc-2371-44c2-9f88-62009088d2ea


https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/47267502-59c2-4a5e-b526-95c149e59440


https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/c9325c79-0654-4646-a347-3184f27c9425




### Issues remaining.
1. cannot move a widget into another group if the group is empty
1. pages without groups are not rendered in layout (user cannot move groups to non-visible page)
1. clicking widget does not reveal/bring into view on the canvas


https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/1ce6ef53-a1e7-4395-aa5b-0ce9297a5c7f

https://github.com/flowforge/flowforge-nr-dashboard/assets/44235289/0e25dafd-34ce-4419-a26d-d848ab6f7ab2




### NOTES:
The layout refresh is brute force. Ideally, this would be don using the hooks [`addItem`](https://nodered.org/docs/api/ui/editableList/#options-addItem) and [`removeItem`](https://nodered.org/docs/api/ui/editableList/#methods-removeItem)


## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

