### PR TITLE
Use page title as tab name in-browser

### DIFF
--- a/ui/src/router.js
+++ b/ui/src/router.js
@@ -7,4 +7,13 @@ const router = createRouter({
     routes
 })
 
+router.beforeEach((to, from, next) => {
+    if (to.meta.title) {
+        document.title = to.meta.title
+    } else {
+        document.title = 'Node-RED Dashboard 2.0'
+    }
+    next()
+})
+
 export default router


### PR DESCRIPTION
## Description

- Uses the page `name` as the page/tab title
- Adds a default page title of `Node-RED Dashboard 2.0

## Related Issue(s)

Closes #155 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
