### PR TITLE
Prevent the forced uppercase button label from Vuetify/Material Design

### DIFF
--- a/ui/src/stylesheets/common.css
+++ b/ui/src/stylesheets/common.css
@@ -37,6 +37,13 @@ main {
 }
 
 /**
+* Widget: Button
+*/
+.v-btn {
+    text-transform: none;
+}
+
+/**
 * Widget: Form
 */ 
 


### PR DESCRIPTION
## Description

- Overrides the default `v-btn` styling for a Material Design button, and allows the use of _any_ case in the Button label text.

## Related Issue(s)

Closes #150 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)