### PR TITLE
Add mobile meta for easy assignment to mobile app lists

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Node-RED Dashboard 2.0">
+    <meta name="mobile-web-app-capable" content="yes">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>


### PR DESCRIPTION
## Description

- Adds `mobile-web-app-capable` to enable assignment of Dasbhoard 2.0 pages to an App on Android
- Add equivalent meta tags for Apple too

## Related Issue(s)

Closes #142 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)