### PR TITLE
Add link to sidebar & remove old order form rows

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -29,6 +29,13 @@
     .nrdb2-layout-order-editor {
         padding: 8px 10px;
     }
+    .nrdb2-layout-helptext {
+        padding: 0 0 9px;
+        font-style: italic;
+        color: #a2a2a2;
+        font-size: 8pt;
+        line-height: 12pt;
+    }
     .nrdb2-layout-order-editor--pages {
         display: flex;
         justify-content: space-between;
@@ -439,6 +446,8 @@
             .appendTo(buttonGroup)
         RED.popover.tooltip(buttonExpand, c_('layout.expand'))
 
+        divTabs.append('<div class="nrdb2-layout-helptext">Here you can re-order and move your widgets, groups and pages.</div>')
+
         const pages = {}
         const groupsByPage = {}
         const widgetsByGroup = {}
@@ -556,9 +565,6 @@
 
             // add layout editor
             buildLayoutOrderEditor()
-
-            // placeholder message
-            sidebar.append('<span style="padding: 9px; font-style: italic; color: #a2a2a2; font-size: 8pt;">More content will be added here in future releases</span>')
         }
     })
 

--- a/nodes/config/ui_group.html
+++ b/nodes/config/ui_group.html
@@ -42,10 +42,9 @@
         <button class="editor-button" id="node-config-input-size"></button>
     </div>
     <div class="form-row">
-        <label for="node-config-input-order"><i class="fa fa-bookmark"></i> Order</label>
-        <input type="text" id="node-config-input-order">
+        <input style="margin:8px 0 10px 102px; width:20px;" type="checkbox" checked id="node-config-input-disp"> <label style="width:auto" for="node-config-input-disp"><span data-i18n="ui-group.display-name"></span></label>
     </div>
     <div class="form-row">
-        <input style="margin:8px 0 10px 102px; width:20px;" type="checkbox" checked id="node-config-input-disp"> <label style="width:auto" for="node-config-input-disp"><span data-i18n="ui-group.display-name"></span></label>
+        <button onclick="RED.sidebar.show('dashboard-2.0')" class="editor-button editor-button-small">Open Dashboard 2.0 Sidebar</button>
     </div>
 </script>

--- a/nodes/config/ui_page.html
+++ b/nodes/config/ui_page.html
@@ -73,8 +73,6 @@
         <input type="hidden" id="node-config-input-layoutType">
     </div>
     <div class="form-row">
-        <label for="node-config-input-layout"><i class="fa fa-bookmark"></i> Order</label>
-        <input type="text" id="node-config-input-order">
-        <input type="hidden" id="node-config-input-orderType">
+        <button onclick="RED.sidebar.show('dashboard-2.0')" class="editor-button editor-button-small">Open Dashboard 2.0 Sidebar</button>
     </div>
 </script>


### PR DESCRIPTION
## Description

In prep for 0.3.0 release, noticed that the old `order` form rows were still present on Groups and Pages, so removed them, and instead, added a link to the Dashboard 2.0 sidebar. 

I've also added a little bit of helper text to the sidebar to instruct users that you can drag/drop for re-ordering.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)