### PR TITLE
Fix dashboard not working when custom `httpNodeRoot` path is set

### DIFF
--- a/nodes/config/ui_base.html
+++ b/nodes/config/ui_base.html
@@ -140,7 +140,11 @@
     const sidebar = $(sidebarContentTemplate)
 
     function uiLink (name, path) {
-        return `<div class="red-ui-sidebar-header"><label>${name}</label><a id="open-dashboard" href="${path}" target="nr-dashboard" class="editor-button editor-button-small nrdb2-sb-list-header-button">Open Dashboard<i style="margin-left: 3px;" class="fa fa-external-link"></i></a></div>`
+        const base = RED.settings.httpNodeRoot || '/'
+        const basePart = base.endsWith('/') ? base : `${base}/`
+        const dashPart = path.startsWith('/') ? path.slice(1) : path
+        const fullPath = `${basePart}${dashPart}`
+        return `<div class="red-ui-sidebar-header"><label>${name}</label><a id="open-dashboard" href="${fullPath}" target="nr-dashboard" class="editor-button editor-button-small nr-db-sb-list-header-button">Open Dashboard<i style="margin-left: 3px;" class="fa fa-external-link"></i></a></div>`
     }
 
     /**

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -45,11 +45,18 @@ const vuetify = createVuetify({
 
 import store from './store/index.js'
 
-/**
+/*
  * Configure SocketIO Client to Interact with Node-RED
  */
-const path = '/dashboard/socket.io'
-console.log(`Connecting to Node-RED via SocketIO at ${path}`)
+// Inspect the current URL to determine the correct path to use for socket.io.
+// for example, the base path might be `:1880/` or if `httpNodeRoot` is set, it could be something like `:1880/nr/endpoints/v1`
+// 1. determine the base path to use (grab everything before the first /dashboard)
+// 2. append '/socket.io' to the base path
+// TODO: determine what to do when /dashboard is called something else (support multiple dashboards github #23 )
+//       possible idea: pass the base path as a query param from the side bar, extract it then redirect?
+const url = new URL(window.location.href)
+const basePath = url.pathname.split('/dashboard')[0]
+const path = basePath + '/dashboard/socket.io'
 const socket = io({
     path
 })


### PR DESCRIPTION
closes #163

## Description

This is a temporary* fix to get dashboard2 working when the user has set `httpNodePath` to move the express endpoints.

I needed to fix this to review #164 - so raised it while fresh in mind.

### *temporary
There is currently no way to know (in main.js) what the base path of the Node-RED instance is but we need this to setup the socket.io. 
While #23 is unresolved, this is not an issue since the dashboard is hard coded to be `/dashboard` so we will always be able to determine the base path by grabbing everything before `/dashboard`  from the pages href. But when #23 is implemented, we will need a way to distinguish the following possible URLs
* `http://xxxxx:port/nr/api/v1/section1/page2` // dashboard was named `section1` so base URL is `http://xxxxx:port/nr/api/v1`
* `http://xxxxx:port/nr/api/v1/section1/page2` // dashboard was named `v1` so base URL is `http://xxxxx:port/nr/api/`
* `http://xxxxx:port/nr/api/v1/page/2` // dashboard was named `v1` so base URL is `http://xxxxx:port/nr/api/`
* `http://xxxxx:port/nr/api/v1/pages/2` // dashboard was named `pages` so base URL is `http://xxxxx:port/nr/api/v1`


## Related Issue(s)

#163

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

