### PR TITLE
Only emit the "value" when dropdown selection is changed

### DIFF
--- a/ui/src/widgets/ui-dropdown/UIDropdown.vue
+++ b/ui/src/widgets/ui-dropdown/UIDropdown.vue
@@ -87,9 +87,20 @@ export default {
         onChange () {
             // ensure our data binding with vuex store is updated
             const msg = this.messages[this.id] || {}
-            msg.payload = this.value
+            if (this.props.multiple) {
+                // return an array
+                msg.payload = this.value.map((option) => {
+                    return option.value
+                })
+            } else if (this.value) {
+                // return a single value
+                msg.payload = this.value.value
+            } else {
+                // return null
+                msg.payload = null
+            }
             this.$store.commit('data/bind', msg)
-            this.$socket.emit('widget-change', this.id, this.value)
+            this.$socket.emit('widget-change', this.id, msg.payload)
         }
     }
 }


### PR DESCRIPTION
## Description

- For single selection dropdown, will just emit the value as `msg.payload`
- For multi-selection dropdown, will emit an array containing the selected values in `mag.payload`

## Related Issue(s)

Fixes #127 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)