### PR TITLE
141 switch params

### DIFF
--- a/nodes/utils/index.js
+++ b/nodes/utils/index.js
@@ -1,0 +1,35 @@
+function asyncEvaluateNodeProperty (RED, value, type, node, msg) {
+    return new Promise(function (resolve, reject) {
+        RED.util.evaluateNodeProperty(value, type, node, msg, function (e, r) {
+            if (e) {
+                reject(e)
+            } else {
+                resolve(r)
+            }
+        })
+    })
+}
+
+async function appendTopic (RED, config, wNode, msg) {
+    // populate topic if the node specifies one
+    if (config.topic || config.topicType) {
+        try {
+            msg.topic = await asyncEvaluateNodeProperty(RED, config.topic, config.topicType || 'str', wNode, msg) || ''
+        } catch (_err) {
+            // do nothing
+            console.error(_err)
+        }
+    }
+
+    // ensure we have a topic property in the msg, even if it's an empty string
+    if (!('topic' in msg)) {
+        msg.topic = ''
+    }
+
+    return msg
+}
+
+module.exports = {
+    asyncEvaluateNodeProperty,
+    appendTopic
+}

--- a/nodes/widgets/ui_dropdown.js
+++ b/nodes/widgets/ui_dropdown.js
@@ -9,12 +9,7 @@ module.exports = function (RED) {
         const group = RED.nodes.getNode(config.group)
 
         const evts = {
-            onChange: true,
-            onInput: function (msg, send) {
-                if (config.passthru) {
-                    send(msg)
-                }
-            }
+            onChange: true
         }
 
         // inform the dashboard UI that we are adding this node

--- a/nodes/widgets/ui_radio_group.html
+++ b/nodes/widgets/ui_radio_group.html
@@ -24,7 +24,7 @@
                 },
                 height: { value: 0 },
                 columns: { value: 1 },
-                passthru: { value: true },
+                passthru: { value: false },
                 options: {
                     value: [{ value: '', label: '' }],
                     validate: function (v) {
@@ -178,5 +178,9 @@
         <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
         <input type="text" id="node-input-topic" style="width:70%" placeholder="optional msg.topic">
         <input type="hidden" id="node-input-topicType">
+    </div>
+    <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
 </script>

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -126,7 +126,7 @@
                 <option value="all">continuously while sliding</option>
                 <option value="end">only on release</option>
             </select>
-        </div>
+        </div>-->
         <div class="form-row">
             <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
             <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
@@ -134,14 +134,14 @@
         <div class="form-row">
             <label style="width:auto" for="node-input-payload"><i class="fa fa-envelope-o"></i> When changed, send:</label>
         </div>
-        <div class="form-row">
+        <!-- <div class="form-row">
             <label style="padding-left:25px; margin-right:-25px">Payload</label>
             <label style="width:auto">Current value</label>
-        </div>
+        </div> -->
         <div class="form-row">
             <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
             <input type="text" id="node-input-topic">
-        </div>-->
+        </div>
     </div>
 </script>
 

--- a/nodes/widgets/ui_slider.html
+++ b/nodes/widgets/ui_slider.html
@@ -24,7 +24,7 @@
                     }
                 },
                 height: { value: 0 },
-                passthru: { value: true },
+                passthru: { value: false },
                 outs: { value: 'all' },
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -24,7 +24,7 @@
                     }
                 },
                 height: { value: 0 },
-                passthru: { value: true },
+                passthru: { value: false },
                 topic: { value: 'topic', validate: (hasProperty(RED.validators, 'typedInput') ? RED.validators.typedInput('topicType') : function (v) { return true }) },
                 topicType: { value: 'msg' },
                 style: { value: '' },
@@ -170,6 +170,10 @@
         <input type="text" id="node-input-offcolor" style="width:120px">
     </div>
     <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row">
         <label style="width:auto" for="node-input-onvalue"><i class="fa fa-envelope-o"></i> When clicked, send:</label>
     </div>
     <div class="form-row">
@@ -181,10 +185,6 @@
         <label for="node-input-offvalue" style="padding-left:25px; margin-right:-25px">Off Payload</label>
         <input type="text" id="node-input-offvalue" style="width:70%">
         <input type="hidden" id="node-input-offvalueType">
-    </div>
-    <div class="form-row">
-        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
-        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
     </div>
     <div class="form-row">
         <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>

--- a/nodes/widgets/ui_switch.html
+++ b/nodes/widgets/ui_switch.html
@@ -182,9 +182,13 @@
         <input type="text" id="node-input-offvalue" style="width:70%">
         <input type="hidden" id="node-input-offvalueType">
     </div>
-    <!--<div class="form-row">
+    <div class="form-row">
+        <label style="width:auto" for="node-input-passthru"><i class="fa fa-arrow-right"></i> If <code>msg</code> arrives on input, pass through to output: </label>
+        <input type="checkbox" checked id="node-input-passthru" style="display:inline-block; width:auto; vertical-align:top;">
+    </div>
+    <div class="form-row">
         <label for="node-input-topic" style="padding-left:25px; margin-right:-25px">Topic</label>
         <input type="text" id="node-input-topic">
         <input type="hidden" id="node-input-topicType">
-    </div>-->
+    </div>
 </script>

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -1,3 +1,5 @@
+const { appendTopic } = require('../utils/index.js')
+
 module.exports = function (RED) {
     function SwitchNode (config) {
         // create node in Node-RED
@@ -14,7 +16,7 @@ module.exports = function (RED) {
         const evts = {
             // runs on UI interaction
             // value = true | false from the ui-switch
-            onChange: function (value) {
+            onChange: async function (value) {
                 // ensure we have latest instance of the widget's node
                 const wNode = RED.nodes.getNode(node.id)
                 const msg = wNode._msg || {}
@@ -35,7 +37,7 @@ module.exports = function (RED) {
                 // simulate Node-RED node receiving an input
                 wNode.send(msg)
             },
-            onInput: function (msg, send) {
+            onInput: async function (msg, send) {
                 let error = null
                 // ensure we have latest instance of the widget's node
                 const wNode = RED.nodes.getNode(node.id)
@@ -63,6 +65,13 @@ module.exports = function (RED) {
                 } else {
                     node.error(error)
                 }
+            },
+            beforeSend: async function (msg) {
+                // ensure we have latest instance of the widget's node
+                const wNode = RED.nodes.getNode(node.id)
+
+                msg = await appendTopic(RED, config, wNode, msg)
+                return msg
             }
         }
 

--- a/nodes/widgets/ui_switch.js
+++ b/nodes/widgets/ui_switch.js
@@ -57,8 +57,9 @@ module.exports = function (RED) {
                         shape: 'ring',
                         text: msg.payload ? states[1] : states[0]
                     })
-
-                    send(msg)
+                    if (config.passthru) {
+                        send(msg)
+                    }
                 } else {
                     node.error(error)
                 }


### PR DESCRIPTION
## Description

- Centralises handling for `passthru` and `topic` into the `on('input')` in `ui-base.js`
    - Remove dedicated handlers (e.g. in `ui-dropdown`) for `passthru` and `topic` that are now centralised.
- Exposes `passthru` option for  `ui-switch` (default: false)
- Exposes `passthru` option for  `ui-radio-group` (default: false)
- Exposes `passthru` option for  `ui-slider` (default: false)
- Exposes `topic` option for  `ui-slider`
- Add custom handlers in `beforeSend` for `ui-switch` to calculate `topic` given it has an overriding `onInput` 

## Related Issue(s)

Fixes #141 
Fixes #177 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)