### PR TITLE
Bump to NR 3.1 to close out security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowforge/node-red-dashboard",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowforge/node-red-dashboard",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "chartjs-adapter-luxon": "^1.3.1",
@@ -43,7 +43,7 @@
                 "medium-zoom": "^1.0.8",
                 "mermaid": "^10.4.0",
                 "mocha": "^10.2.0",
-                "node-red": "^3.0.2",
+                "node-red": "^3.1.0",
                 "node-red-node-test-helper": "^0.3.2",
                 "should": "^13.2.3",
                 "should-sinon": "^0.0.6",
@@ -2871,18 +2871,18 @@
             }
         },
         "node_modules/@node-red/editor-api": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-3.0.2.tgz",
-            "integrity": "sha512-eyWObGLXVKhQDOHX9Fe+oOhC5nZAU8A92M5f4BwCXY1c9wx8QnWZVqOhPleVu3UJxZJEZ44OUdPb+HtsRNmD7Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/editor-api/-/editor-api-3.1.0.tgz",
+            "integrity": "sha512-AUEw0KEelxcDKFsjTDWnTXHycbh75htxWWBgGuMsHKA/0aWLeiLOjTrdyLZmDqV/ytfxJ4ndBl9HO4T/YYKJdw==",
             "dev": true,
             "dependencies": {
-                "@node-red/editor-client": "3.0.2",
-                "@node-red/util": "3.0.2",
+                "@node-red/editor-client": "3.1.0",
+                "@node-red/util": "3.1.0",
                 "bcryptjs": "2.4.3",
-                "body-parser": "1.20.0",
+                "body-parser": "1.20.2",
                 "clone": "2.1.2",
                 "cors": "2.8.5",
-                "express": "4.18.1",
+                "express": "4.18.2",
                 "express-session": "1.17.3",
                 "memorystore": "1.6.7",
                 "mime": "3.0.0",
@@ -2895,31 +2895,25 @@
                 "ws": "7.5.6"
             },
             "optionalDependencies": {
-                "bcrypt": "5.0.1"
+                "bcrypt": "5.1.0"
             }
         },
-        "node_modules/@node-red/editor-api/node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true
-        },
         "node_modules/@node-red/editor-api/node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -2946,15 +2940,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/@node-red/editor-api/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/@node-red/editor-api/node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2962,48 +2947,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "2.0.0"
-            }
-        },
-        "node_modules/@node-red/editor-api/node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
             }
         },
         "node_modules/@node-red/editor-api/node_modules/mime": {
@@ -3024,19 +2967,19 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/@node-red/editor-api/node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+        "node_modules/@node-red/editor-api/node_modules/raw-body": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
             },
             "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">= 0.8"
             }
         },
         "node_modules/@node-red/editor-api/node_modules/ws": {
@@ -3061,33 +3004,33 @@
             }
         },
         "node_modules/@node-red/editor-client": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-3.0.2.tgz",
-            "integrity": "sha512-UlbsoEnIfpQO0yKf55Kd2qCwItDjfM9ut6FUfd2x10yKk9RxrA1rQPsW7PiB7gV/E1aW1JPmMxrmfHbb9Gdf8w==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/editor-client/-/editor-client-3.1.0.tgz",
+            "integrity": "sha512-4hLeDNkNh+GPqF6XNJo+kDY8JkmEwfiVEbd0BEagmlf/Kcu7rHjGJzJceqGxwNXy4MS5rINsTHjziwbTgd/MXw==",
             "dev": true
         },
         "node_modules/@node-red/nodes": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-3.0.2.tgz",
-            "integrity": "sha512-H2rH2U5uEic4nwyabkiTIYNYGLTJL6TIccdPwz7AAykTmD5naKLs3nhuPHjzb54iPen/SU9jkJoU7iecslOk6g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/nodes/-/nodes-3.1.0.tgz",
+            "integrity": "sha512-GxviusR8TY39j56KSOrBVj3/Jscs/MCn0+TDE0/9qI5K64+V4D52xwhwC5AMVWDUVB/xeXJRk+W6yOIcQb9FvQ==",
             "dev": true,
             "dependencies": {
-                "acorn": "8.7.1",
+                "acorn": "8.8.2",
                 "acorn-walk": "8.2.0",
-                "ajv": "8.11.0",
-                "body-parser": "1.20.0",
+                "ajv": "8.12.0",
+                "body-parser": "1.20.2",
                 "cheerio": "1.0.0-rc.10",
-                "content-type": "1.0.4",
+                "content-type": "1.0.5",
                 "cookie": "0.5.0",
                 "cookie-parser": "1.4.6",
                 "cors": "2.8.5",
                 "cronosjs": "1.7.1",
                 "denque": "2.1.0",
                 "form-data": "4.0.0",
-                "fs-extra": "10.1.0",
-                "got": "11.8.5",
+                "fs-extra": "11.1.1",
+                "got": "12.6.0",
                 "hash-sum": "2.0.0",
-                "hpagent": "1.0.0",
+                "hpagent": "1.2.0",
                 "https-proxy-agent": "5.0.1",
                 "iconv-lite": "0.6.3",
                 "is-utf8": "0.2.1",
@@ -3096,19 +3039,19 @@
                 "mqtt": "4.3.7",
                 "multer": "1.4.5-lts.1",
                 "mustache": "4.2.0",
-                "node-watch": "0.7.3",
+                "node-watch": "0.7.4",
                 "on-headers": "1.0.2",
-                "raw-body": "2.5.1",
-                "tough-cookie": "4.0.0",
-                "uuid": "8.3.2",
+                "raw-body": "2.5.2",
+                "tough-cookie": "4.1.3",
+                "uuid": "9.0.0",
                 "ws": "7.5.6",
-                "xml2js": "0.4.23"
+                "xml2js": "0.6.2"
             }
         },
         "node_modules/@node-red/nodes/node_modules/acorn": {
-            "version": "8.7.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -3118,9 +3061,9 @@
             }
         },
         "node_modules/@node-red/nodes/node_modules/ajv": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -3134,21 +3077,21 @@
             }
         },
         "node_modules/@node-red/nodes/node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
-                "content-type": "~1.0.4",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
             },
@@ -3178,15 +3121,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/@node-red/nodes/node_modules/content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/@node-red/nodes/node_modules/cookie": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -3206,9 +3140,9 @@
             }
         },
         "node_modules/@node-red/nodes/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3216,7 +3150,7 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.14"
             }
         },
         "node_modules/@node-red/nodes/node_modules/iconv-lite": {
@@ -3252,19 +3186,40 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/@node-red/nodes/node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+        "node_modules/@node-red/nodes/node_modules/raw-body": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
             },
             "engines": {
-                "node": ">=0.6"
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/@node-red/nodes/node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@node-red/nodes/node_modules/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@node-red/nodes/node_modules/ws": {
@@ -3289,17 +3244,17 @@
             }
         },
         "node_modules/@node-red/registry": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-3.0.2.tgz",
-            "integrity": "sha512-+vf9R4j+p2nM7awzicIzu6liJgXyoQfhHGv3OxmK9OfBsISn5eWIj9u2HiJtG3ChYfuediK2FEhc+Pb+mhfTJA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/registry/-/registry-3.1.0.tgz",
+            "integrity": "sha512-FMyDZ6kmB8EDaFLvA+vaLlz8wZVnlUMdahGpm+g8mDPIzN9Qs2pEEFfKxWy1146nzNzB4PSqvmxgp/9lsYT/Pg==",
             "dev": true,
             "dependencies": {
-                "@node-red/util": "3.0.2",
+                "@node-red/util": "3.1.0",
                 "clone": "2.1.2",
-                "fs-extra": "10.1.0",
-                "semver": "7.3.7",
-                "tar": "6.1.11",
-                "uglify-js": "3.16.3"
+                "fs-extra": "11.1.1",
+                "semver": "7.5.4",
+                "tar": "6.1.13",
+                "uglify-js": "3.17.4"
             }
         },
         "node_modules/@node-red/registry/node_modules/clone": {
@@ -3312,9 +3267,9 @@
             }
         },
         "node_modules/@node-red/registry/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3322,7 +3277,7 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.14"
             }
         },
         "node_modules/@node-red/registry/node_modules/lru-cache": {
@@ -3338,9 +3293,9 @@
             }
         },
         "node_modules/@node-red/registry/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -3359,57 +3314,18 @@
             "dev": true
         },
         "node_modules/@node-red/runtime": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-3.0.2.tgz",
-            "integrity": "sha512-lEx6riLeEHMshvW84BEN/oUESG1F2AirLCkH6xbws8Ta8fgE6YfsOvgKBMnfbwoUME2O+I/QCkIYZqlqUhqJXg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/runtime/-/runtime-3.1.0.tgz",
+            "integrity": "sha512-KtX3Jua2qu4PwPhBlUGN+QQBwibjx1vyBRaKc4SlZeJos1V5a6MOpYS91soUfIpsJJBHVzisz69SZiRrmgXIHw==",
             "dev": true,
             "dependencies": {
-                "@node-red/registry": "3.0.2",
-                "@node-red/util": "3.0.2",
-                "async-mutex": "0.3.2",
+                "@node-red/registry": "3.1.0",
+                "@node-red/util": "3.1.0",
+                "async-mutex": "0.4.0",
                 "clone": "2.1.2",
-                "express": "4.18.1",
-                "fs-extra": "10.1.0",
+                "express": "4.18.2",
+                "fs-extra": "11.1.1",
                 "json-stringify-safe": "5.0.1"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true
-        },
-        "node_modules/@node-red/runtime/node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8"
             }
         },
         "node_modules/@node-red/runtime/node_modules/clone": {
@@ -3421,70 +3337,10 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/@node-red/runtime/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
         "node_modules/@node-red/runtime/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3492,49 +3348,28 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@node-red/runtime/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/@node-red/runtime/node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-            "dev": true,
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=14.14"
             }
         },
         "node_modules/@node-red/util": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@node-red/util/-/util-3.0.2.tgz",
-            "integrity": "sha512-zhxmFk48QEC4coBN0G0JDHt727+BlZS2QZarWs9hLeNDBdhjlU58RY0lhDgqODu/Z3JvBmIdPhCtDcvHpe4zmw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@node-red/util/-/util-3.1.0.tgz",
+            "integrity": "sha512-VGU0rpt8r/OWeq8KxK9ML9MCi3/sm4Y82nznrUCET4STl+BUA5AtXsjhjffOB7gimAlsGTcmljZHqeWkEWn4oQ==",
             "dev": true,
             "dependencies": {
-                "fs-extra": "10.1.0",
-                "i18next": "21.8.16",
+                "fs-extra": "11.1.1",
+                "i18next": "21.10.0",
                 "json-stringify-safe": "5.0.1",
                 "jsonata": "1.8.6",
                 "lodash.clonedeep": "^4.5.0",
                 "moment": "2.29.4",
-                "moment-timezone": "0.5.34"
+                "moment-timezone": "0.5.43"
             }
         },
         "node_modules/@node-red/util/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -3542,7 +3377,7 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.14"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -3618,12 +3453,12 @@
             "dev": true
         },
         "node_modules/@sindresorhus/is": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+            "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -3770,15 +3605,15 @@
             "dev": true
         },
         "node_modules/@szmarczak/http-timer": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-            "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
             "dev": true,
             "dependencies": {
-                "defer-to-connect": "^2.0.0"
+                "defer-to-connect": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=14.16"
             }
         },
         "node_modules/@trysound/sax": {
@@ -3807,18 +3642,6 @@
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "node_modules/@types/cacheable-request": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-            "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-            "dev": true,
-            "dependencies": {
-                "@types/http-cache-semantics": "*",
-                "@types/keyv": "^3.1.4",
-                "@types/node": "*",
-                "@types/responselike": "^1.0.0"
             }
         },
         "node_modules/@types/connect": {
@@ -3972,15 +3795,6 @@
             "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true
         },
-        "node_modules/@types/keyv": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-            "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/mdast": {
             "version": "3.0.12",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
@@ -4036,15 +3850,6 @@
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
             "dev": true
-        },
-        "node_modules/@types/responselike": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-            "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/retry": {
             "version": "0.12.0",
@@ -5702,12 +5507,12 @@
             }
         },
         "node_modules/async-mutex": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
-            "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+            "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
             "dev": true,
             "dependencies": {
-                "tslib": "^2.3.1"
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/asynckit": {
@@ -5920,15 +5725,15 @@
             "dev": true
         },
         "node_modules/bcrypt": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.1.tgz",
-            "integrity": "sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.0.tgz",
+            "integrity": "sha512-RHBS7HI5N5tEnGTmtR/pppX0mmDSBpQ4aCBsj7CEQfYXDcO74A8sIBYcJMuCsis2E81zDxeENYhv66oZwLiA+Q==",
             "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "node-addon-api": "^3.1.0"
+                "@mapbox/node-pre-gyp": "^1.0.10",
+                "node-addon-api": "^5.0.0"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -6191,42 +5996,51 @@
             }
         },
         "node_modules/cacheable-lookup": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-            "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
             "dev": true,
             "engines": {
-                "node": ">=10.6.0"
+                "node": ">=14.16"
             }
         },
         "node_modules/cacheable-request": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-            "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+            "version": "10.2.13",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+            "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
             "dev": true,
             "dependencies": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^4.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^6.0.1",
-                "responselike": "^2.0.0"
+                "@types/http-cache-semantics": "^4.0.1",
+                "get-stream": "^6.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "keyv": "^4.5.3",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.0.0",
+                "responselike": "^3.0.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=14.16"
             }
         },
         "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cacheable-request/node_modules/normalize-url": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+            "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6660,18 +6474,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/clone-response": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-            "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-            "dev": true,
-            "dependencies": {
-                "mimic-response": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/color-convert": {
@@ -10189,6 +9991,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/form-data-encoder": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.17"
+            }
+        },
         "node_modules/formidable": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
@@ -10538,28 +10349,40 @@
             }
         },
         "node_modules/got": {
-            "version": "11.8.5",
-            "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-            "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
+            "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
             "dev": true,
             "dependencies": {
-                "@sindresorhus/is": "^4.0.0",
-                "@szmarczak/http-timer": "^4.0.5",
-                "@types/cacheable-request": "^6.0.1",
-                "@types/responselike": "^1.0.0",
-                "cacheable-lookup": "^5.0.3",
-                "cacheable-request": "^7.0.2",
+                "@sindresorhus/is": "^5.2.0",
+                "@szmarczak/http-timer": "^5.0.1",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^10.2.8",
                 "decompress-response": "^6.0.0",
-                "http2-wrapper": "^1.0.0-beta.5.2",
-                "lowercase-keys": "^2.0.0",
-                "p-cancelable": "^2.0.0",
-                "responselike": "^2.0.0"
+                "form-data-encoder": "^2.1.2",
+                "get-stream": "^6.0.1",
+                "http2-wrapper": "^2.1.10",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^3.0.0",
+                "responselike": "^3.0.0"
             },
             "engines": {
-                "node": ">=10.19.0"
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/got/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/graceful-fs": {
@@ -10804,9 +10627,9 @@
             }
         },
         "node_modules/hpagent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.0.0.tgz",
-            "integrity": "sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
             "dev": true,
             "engines": {
                 "node": ">=14"
@@ -10975,13 +10798,13 @@
             }
         },
         "node_modules/http2-wrapper": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-            "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+            "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
             "dev": true,
             "dependencies": {
                 "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.0.0"
+                "resolve-alpn": "^1.2.0"
             },
             "engines": {
                 "node": ">=10.19.0"
@@ -11001,9 +10824,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "21.8.16",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.8.16.tgz",
-            "integrity": "sha512-acJLCk38YMfEPjBR/1vS13SFY7rBQLs9E5m1tSRnWc9UW3f+SZszgH+NP1fZRA1+O+CdG2eLGGmuUMJW52EwzQ==",
+            "version": "21.10.0",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+            "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
             "dev": true,
             "funding": [
                 {
@@ -12169,12 +11992,15 @@
             }
         },
         "node_modules/lowercase-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lru-cache": {
@@ -12914,12 +12740,15 @@
             }
         },
         "node_modules/mimic-response": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
             "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mini-css-extract-plugin": {
@@ -13330,12 +13159,12 @@
             }
         },
         "node_modules/moment-timezone": {
-            "version": "0.5.34",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-            "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+            "version": "0.5.43",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+            "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
             "dev": true,
             "dependencies": {
-                "moment": ">= 2.9.0"
+                "moment": "^2.29.4"
             },
             "engines": {
                 "node": "*"
@@ -13640,9 +13469,9 @@
             }
         },
         "node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+            "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
             "dev": true,
             "optional": true
         },
@@ -13676,22 +13505,22 @@
             }
         },
         "node_modules/node-red": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/node-red/-/node-red-3.0.2.tgz",
-            "integrity": "sha512-B6q576kLw96eKOiqNpNJsUiwl5vRipc46T0w/LUI7O3fPAVxwu5zklIBhE6Iefj8FV1IdbLwXULESqMWlwjlGQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/node-red/-/node-red-3.1.0.tgz",
+            "integrity": "sha512-khGc+Fh8YeuDR2KZ7lCTEvAhbRDiXpmMSfvX6eKxt7TER+WVG0U8TdXyiFq6K+3ELnJz54vITJJ3DZ5hYzijoQ==",
             "dev": true,
             "dependencies": {
-                "@node-red/editor-api": "3.0.2",
-                "@node-red/nodes": "3.0.2",
-                "@node-red/runtime": "3.0.2",
-                "@node-red/util": "3.0.2",
+                "@node-red/editor-api": "3.1.0",
+                "@node-red/nodes": "3.1.0",
+                "@node-red/runtime": "3.1.0",
+                "@node-red/util": "3.1.0",
                 "basic-auth": "2.0.1",
                 "bcryptjs": "2.4.3",
-                "express": "4.18.1",
-                "fs-extra": "10.1.0",
-                "node-red-admin": "^3.0.0",
+                "express": "4.18.2",
+                "fs-extra": "11.1.1",
+                "node-red-admin": "^3.1.0",
                 "nopt": "5.0.0",
-                "semver": "7.3.7"
+                "semver": "7.5.4"
             },
             "bin": {
                 "node-red": "red.js",
@@ -13701,21 +13530,21 @@
                 "node": ">=14"
             },
             "optionalDependencies": {
-                "bcrypt": "5.0.1"
+                "bcrypt": "5.1.0"
             }
         },
         "node_modules/node-red-admin": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/node-red-admin/-/node-red-admin-3.0.0.tgz",
-            "integrity": "sha512-1J1tcV+zkCIy24n0rcJ/DSPSCziEgLGld+QBYk1rNESIo+gFyL5RMkCOcII2IrBTZF/kcDTElepMTCILXbMDfQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/node-red-admin/-/node-red-admin-3.1.0.tgz",
+            "integrity": "sha512-qEFVajV++p2sZjt9uaQeF92Or0SN5YWRv5C8HYI6JCKO4rv7d4JqXFvw7l3RjkBYUjUAkKSB69BrFe2Gtv8XOQ==",
             "dev": true,
             "dependencies": {
-                "ansi-colors": "^4.1.1",
+                "ansi-colors": "^4.1.3",
                 "axios": "0.27.2",
                 "bcryptjs": "^2.4.3",
                 "cli-table": "^0.3.11",
                 "enquirer": "^2.3.6",
-                "minimist": "^1.2.6",
+                "minimist": "^1.2.8",
                 "mustache": "^4.2.0",
                 "read": "^1.0.7"
             },
@@ -13726,7 +13555,22 @@
                 "node": ">=14"
             },
             "optionalDependencies": {
-                "bcrypt": "5.0.1"
+                "bcrypt": "5.1.1"
+            }
+        },
+        "node_modules/node-red-admin/node_modules/bcrypt": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+            "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "@mapbox/node-pre-gyp": "^1.0.11",
+                "node-addon-api": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/node-red-node-test-helper": {
@@ -13970,109 +13814,10 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
         },
-        "node_modules/node-red/node_modules/array-flatten": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-            "dev": true
-        },
-        "node_modules/node-red/node_modules/body-parser": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
-            "dev": true,
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.10.3",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/node-red/node_modules/bytes": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/node-red/node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-red/node_modules/debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/node-red/node_modules/express": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
-            "dev": true,
-            "dependencies": {
-                "accepts": "~1.3.8",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.20.0",
-                "content-disposition": "0.5.4",
-                "content-type": "~1.0.4",
-                "cookie": "0.5.0",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "2.4.1",
-                "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.7",
-                "qs": "6.10.3",
-                "range-parser": "~1.2.1",
-                "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
-                "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
-                "type-is": "~1.6.18",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.10.0"
-            }
-        },
         "node_modules/node-red/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+            "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
@@ -14080,7 +13825,7 @@
                 "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14.14"
             }
         },
         "node_modules/node-red/node_modules/lru-cache": {
@@ -14095,31 +13840,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/node-red/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-            "dev": true
-        },
-        "node_modules/node-red/node_modules/qs": {
-            "version": "6.10.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-            "dev": true,
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/node-red/node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -14144,9 +13868,9 @@
             "dev": true
         },
         "node_modules/node-watch": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
-            "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.4.tgz",
+            "integrity": "sha512-RinNxoz4W1cep1b928fuFhvAQ5ag/+1UlMDV7rbyGthBIgsiEouS4kvRayvvboxii4m8eolKOIBo3OjDqbc+uQ==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -14589,12 +14313,12 @@
             }
         },
         "node_modules/p-cancelable": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-            "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=12.20"
             }
         },
         "node_modules/p-finally": {
@@ -15597,6 +15321,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "dev": true
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15938,12 +15668,15 @@
             }
         },
         "node_modules/responselike": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-            "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
             "dev": true,
             "dependencies": {
-                "lowercase-keys": "^2.0.0"
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -17128,30 +16861,27 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+            "version": "6.1.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+            "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
             "dev": true,
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
+                "minipass": "^4.0.0",
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=10"
             }
         },
         "node_modules/tar/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+            "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
             "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -17377,23 +17107,24 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-            "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
-                "universalify": "^0.1.2"
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
             },
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/tough-cookie/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "engines": {
                 "node": ">= 4.0.0"
@@ -17558,9 +17289,9 @@
             "dev": true
         },
         "node_modules/uglify-js": {
-            "version": "3.16.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-            "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
             "dev": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -17724,6 +17455,16 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dev": true,
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
             }
         },
         "node_modules/util-deprecate": {
@@ -18897,9 +18638,9 @@
             }
         },
         "node_modules/xml2js": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+            "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
             "dev": true,
             "dependencies": {
                 "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "medium-zoom": "^1.0.8",
         "mermaid": "^10.4.0",
         "mocha": "^10.2.0",
-        "node-red": "^3.0.2",
+        "node-red": "^3.1.0",
         "node-red-node-test-helper": "^0.3.2",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",


### PR DESCRIPTION
Updating to NR 3.1 as a dev dependency should close out all outstanding dependbot security warnings.