### PR TITLE
npm: Add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@flowforge/node-red-dashboard",
+    "homepage": "https://dashboard.flowfuse.com",
     "version": "0.5.0",
     "description": "A collection of Node-RED nodes that provide functionality to build your own UI applications (inc. forms, buttons, charts) within Node-RED.",
     "author": {


### PR DESCRIPTION
## Description

Per [npm the docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#homepage) we can alter the homepage on the NPM website and beyond to point to the docs. I think that's a better location than the repository, and on NPM that's already linked.
