### PR TITLE
SEO: Remove duplicate title

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -1,4 +1,4 @@
-# Node-RED Dashboard 2.0
+# About Node-RED Dashboard 2.0
 
 Welcome to the documentation for the Node-RED Dashboard 2.0, the successor to the original, and very popular, [Node-RED Dashboard](https://flows.nodered.org/node/node-red-dashboard).
 


### PR DESCRIPTION
Search engines don't like duplicate titles as the value of the tag is deminished. For this site, there's only one duplicate title. This change fixes that.
